### PR TITLE
バージョン6.3.2対応

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch-concatenation-token-filter</artifactId>
-    <version>6.2.4.0</version>
+    <version>6.3.2.0</version>
     <packaging>jar</packaging>
     <description>Elasticsearch concatenation token filter plugin</description>
 
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncodint>UTF-8</project.build.sourceEncodint>
-        <elasticsearch.version>6.2.4</elasticsearch.version>
+        <elasticsearch.version>6.3.2</elasticsearch.version>
         <lucene.version>7.2.1</lucene.version>
         <hamcrest.version>1.3</hamcrest.version>
         <guava.version>19.0</guava.version>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -8,13 +8,11 @@
     <files>
         <file>
             <source>src/main/resources/plugin-descriptor.properties</source>
-            <outputDirectory>/elasticsearch/</outputDirectory>
             <filtered>true</filtered>
         </file>
     </files>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>/elasticsearch/</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>
@@ -22,7 +20,6 @@
             </excludes>
         </dependencySet>
         <dependencySet>
-            <outputDirectory>/elasticsearch/</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <includes>
@@ -30,7 +27,6 @@
             </includes>
         </dependencySet>
         <dependencySet>
-            <outputDirectory>/elasticsearch/</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <includes>


### PR DESCRIPTION
AWS の Elasticsearch Service 最新バージョンで動作するようにしました。